### PR TITLE
prevent global variables access

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19,6 +19,7 @@ not_globals = {
 
 ignore = {
     --"6.", -- ignore whitespace warnings
+    "211/_ENV", -- unused variable
 }
 
 

--- a/src/binaryheap.lua
+++ b/src/binaryheap.lua
@@ -32,8 +32,11 @@
 --  * payloads - array of payloads (unique binary heap only)
 --  * reverse - map from payloads to indices (unique binary heap only)
 
-local M = {}
+local assert = assert
 local floor = math.floor
+local _ENV = nil
+
+local M = {}
 
 --================================================================
 -- basic heap sorting algorithm


### PR DESCRIPTION
with the Lua 5.2 idiom : `local _ENV = nil`